### PR TITLE
Fix Discord Button Width

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,7 +59,6 @@ function App() {
           <a
             href="https://web3philippines.org/discord"
             target="_blank"
-            className="icon-style"
             rel="noreferrer noopener"
           >
             <Discord color="#fff" size={24} className="icon-style" /> Discord


### PR DESCRIPTION
The width of the Discord Button is not equal to other buttons
![Discord Button](https://user-images.githubusercontent.com/45262256/202905560-5a7ae2f2-5b66-438b-b540-86729979bb68.png)
